### PR TITLE
fixed removing templates (LXC Images) and made some improvements 

### DIFF
--- a/cmd/createtemplate.go
+++ b/cmd/createtemplate.go
@@ -84,6 +84,13 @@ to quickly create a Cobra application.`,
 			log.Error("Error stopping container: " + err.Error())
 			os.Exit(1)
 		}
+
+		// evaluate template in relations.yaml
+		err = setContainerTemplateRelation(lxclient, "", name, true)
+		if err != nil {
+			log.Error("Error writing template to database: " + err.Error())
+			os.Exit(1)
+		}
 	},
 }
 

--- a/cmd/relationstemplate.go
+++ b/cmd/relationstemplate.go
@@ -51,7 +51,7 @@ func setContainerTemplateRelation(c *lxd.Client, container string, tmpl string, 
 		}
 
 		// append template users which is a container
-		// if an entry is already there an return to caller
+		// if an entry is already there, then return to caller
 		for i, template := range templates.Templates {
 			if tmpl == template.Name {
 
@@ -62,7 +62,7 @@ func setContainerTemplateRelation(c *lxd.Client, container string, tmpl string, 
 					}
 				}
 
-				templates.Templates[i].UsedBy += "," + container
+				templates.Templates[i].UsedBy += container + ","
 				err = templates.store()
 				if err != nil {
 					return errors.Wrap(err, "Failed storing")
@@ -87,11 +87,11 @@ func setContainerTemplateRelation(c *lxd.Client, container string, tmpl string, 
 
 		err := templates.parse()
 		if err != nil {
-			return errors.Wrap(err, "Failed parse data")
+			return errors.Wrap(err, "Failed parse yaml data")
 		}
 
 		if templates.Templates == nil {
-			return fmt.Errorf(i18n.G("Error no image entry here, maybe something went wrong?"))
+			return fmt.Errorf(i18n.G("Error no LXC Image entry here, maybe something went wrong?"))
 		}
 
 		for i, template := range templates.Templates {
@@ -119,8 +119,14 @@ func setContainerTemplateRelation(c *lxd.Client, container string, tmpl string, 
 func writeEntry(t *Templates, container string, tmpl string, fingerprint string) error {
 	img := &Image{Fingerprint: fingerprint}
 
-	template := Template{Name: tmpl, UsedBy: container, Image: img}
-	t.Templates = append(t.Templates, template)
+	if container == "" {
+		fmt.Println("Storing: ", tmpl, "in yaml.")
+		template := Template{Name: tmpl, Image: img}
+		t.Templates = append(t.Templates, template)
+	} else {
+		template := Template{Name: tmpl, UsedBy: container, Image: img}
+		t.Templates = append(t.Templates, template)
+	}
 
 	err := t.store()
 	if err != nil {
@@ -133,37 +139,54 @@ func writeEntry(t *Templates, container string, tmpl string, fingerprint string)
 // Removing the templates which is an LXC image
 func removeTemplate(c *lxd.Client, tmpl string) error {
 	var templates Templates
+	var success bool = false
 
 	fingerprint, err := c.GetImageFingerprint(tmpl)
 	if err != nil {
-		return errors.Wrap(err, "Failed getting fingerprint")
+		return errors.Wrap(err, "Failed getting LCX Image fingerprint")
+	} else if fingerprint == "" {
+		return fmt.Errorf(i18n.G("Error there is no " + tmpl + " (anymore) here. Giving up nothing to remove."))
 	}
 
 	err = templates.parse()
 	if err != nil {
-		return errors.Wrap(err, "Failed parse data")
+		return errors.Wrap(err, "Failed parse yaml data")
 	}
 
 	for i, template := range templates.Templates {
 		if template.UsedBy == "" && template.Name == tmpl {
 			err = c.ContainerRemove(tmpl)
 			if err != nil {
-				return errors.Wrap(err, "Failed remove template container")
+				cause := err.Error()
+				switch cause {
+				case "not found":
+					log.Error("Error container " + tmpl + " not found, maybe it's deleted accidentally, I try to remove the related LXC Image.....")
+					suberr := lxd.RemoveTemplateImage(c, fingerprint)
+					if suberr != nil {
+						return errors.Wrap(err, "Failed remove LXC Image "+tmpl)
+					}
+					log.Success("I was able to remove the template LXC Image")
+					success = true
+				default:
+					return errors.Wrap(err, "Failed remove template container")
+				}
 			}
-			err = lxd.RemoveTemplateImage(c, fingerprint)
-			if err != nil {
-				return errors.Wrap(err, "Failed remove template image "+tmpl)
+			if !success {
+				err = lxd.RemoveTemplateImage(c, fingerprint)
+				if err != nil {
+					return errors.Wrap(err, "Failed remove template LXC Image "+tmpl)
+				}
 			}
 			copy(templates.Templates[i:], templates.Templates[i+1:])
 			templates.Templates[len(templates.Templates)-1] = Template{}
 			templates.Templates = templates.Templates[:len(templates.Templates)-1]
 			err = templates.store()
 			if err != nil {
-				return errors.Wrap(err, "Failed parse data")
+				return errors.Wrap(err, "Failed parse yaml data")
 			}
 			break
 		} else if template.Name == tmpl {
-			return fmt.Errorf(i18n.G("Error can not remove image, it's still in use by " + template.UsedBy))
+			return fmt.Errorf(i18n.G("Error can not remove LXC Image, it's still in use by " + strings.Trim(template.UsedBy, ",") + " !"))
 		}
 	}
 

--- a/lxd/client.go
+++ b/lxd/client.go
@@ -150,7 +150,7 @@ func (c *Client) ContainerInfo(name string) (*api.Container, error) {
 func (c *Client) ContainerRemove(name string) error {
 	cont, err := GetContainer(c.conn, name)
 	if err != nil {
-		return errors.Wrap(err, "getting container")
+		return err
 	}
 	return cont.Remove()
 }

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -46,7 +46,13 @@ type sourceFile struct {
 func GetContainer(conn client.ContainerServer, name string) (*Container, error) {
 	container, etag, err := conn.GetContainer(name)
 	if err != nil {
-		return &Container{}, errors.Wrap(err, "getting container")
+		cause := err.Error()
+		switch cause {
+		case "not found":
+			return &Container{}, err
+		default:
+			return &Container{}, errors.Wrap(err, "getting container")
+		}
 	}
 	return &Container{
 		container: container,


### PR DESCRIPTION
We are now able to rm templates (LXC Images) even then the related container is deleted, e.g. guitemplate. You can still create projects even if the e.g. guitemplate container was removed. 

Evaluating the template (LXC Image in relations.yaml) on creation -> before not and therefore we can't remove the template (LXC Image) devlx doesn't know it's there

Improved error messages and error handling ("not found")
